### PR TITLE
Patch

### DIFF
--- a/src/features/chats/chat-list/components/chat-list-item/components/address-preview/hooks/index.ts
+++ b/src/features/chats/chat-list/components/chat-list-item/components/address-preview/hooks/index.ts
@@ -1,99 +1,35 @@
-import { useCallback, useEffect, useState } from 'react';
-
-import { NDKRelaySet, NDKSubscriptionCacheUsage } from '@nostr-dev-kit/ndk';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { useNdk } from 'nostr-hooks';
-import { nip19 } from 'nostr-tools';
+import { useEffect, useState } from 'react';
 
-import { useToast } from '@/shared/components/ui/use-toast';
-
-import { AddressCategory, NostrEvent } from '../types';
+import { AddressCategory } from '../types';
 
 export const useAddressPreview = (address: string) => {
-  const [eventData, setEventData] = useState<NostrEvent | null>(null);
-  const [category, setCategory] = useState<AddressCategory | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [eventData, setEventData] = useState<NDKEvent | null | undefined>(undefined);
+  const [category, setCategory] = useState<AddressCategory | null | undefined>(undefined);
 
-  const { toast } = useToast();
   const { ndk } = useNdk();
 
-  const fetchData = useCallback(async () => {
+  useEffect(() => {
     if (!ndk) {
-      toast({
-        title: 'Error',
-        description: 'NDK instance is not available.',
-        variant: 'destructive',
-      });
       return;
     }
 
-    setLoading(true);
-
-    try {
-      const decoded = nip19.decode(address);
-
-      if (decoded.type !== 'naddr') {
-        toast({
-          title: 'Error',
-          description: 'Invalid address type. Expected "naddr".',
-          variant: 'destructive',
-        });
-        throw new Error("Invalid address type. Expected 'naddr'.");
-      }
-
-      const { identifier, pubkey, kind, relays = [] } = decoded.data;
-      const relaySet = NDKRelaySet.fromRelayUrls(
-        relays.length > 0 ? relays : ['wss://relay.nostr.band'],
-        ndk,
-      );
-
-      const event = await ndk.fetchEvent(
-        { kinds: [kind], authors: [pubkey], '#d': [identifier] },
-        {
-          closeOnEose: true,
-          cacheUsage: NDKSubscriptionCacheUsage.CACHE_FIRST,
-        },
-        relaySet,
-      );
-
-      if (event) {
-        const rawEvent = event.rawEvent() as NostrEvent;
-        setEventData(rawEvent);
-
-        let determinedCategory: AddressCategory | null = null;
-
-        if (kind === 30000) {
-          determinedCategory = 'usersList';
-        } else if (kind >= 39000 && kind <= 39009) {
-          determinedCategory = 'group';
+    ndk.fetchEvent(address).then((event) => {
+      if (event && event.kind) {
+        if (event.kind === 30000) {
+          setCategory('users-list');
+        } else if (event.kind >= 39000 && event.kind <= 39009) {
+          setCategory('group');
         }
 
-        setCategory(determinedCategory);
+        setEventData(event);
       } else {
         setEventData(null);
         setCategory(null);
       }
-    } catch (err: any) {
-      toast({
-        title: 'Error',
-        description: err.message || 'An error occurred while fetching data.',
-        variant: 'destructive',
-      });
-      setEventData(null);
-      setCategory(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [address, ndk, toast]);
+    });
+  }, [address, ndk]);
 
-  useEffect(() => {
-    fetchData();
-
-    return () => {
-      setEventData(null);
-      setCategory(null);
-      setLoading(false);
-    };
-  }, [fetchData]);
-
-  return { eventData, category, loading };
+  return { eventData, category };
 };

--- a/src/features/chats/chat-list/components/chat-list-item/components/address-preview/index.tsx
+++ b/src/features/chats/chat-list/components/chat-list-item/components/address-preview/index.tsx
@@ -1,9 +1,9 @@
 import { cn } from '@/shared/utils';
 
+import { Spinner } from '@/shared/components/spinner';
+
 import { GroupWidget } from '@/features/groups';
 import { UsersList } from '@/features/users';
-
-import { Spinner } from '@/shared/components/spinner';
 
 import { useAddressPreview } from './hooks';
 
@@ -14,26 +14,31 @@ export const AddressPreview = ({
   address: string;
   sameAsCurrentUser: boolean;
 }) => {
-  const { eventData, category, loading } = useAddressPreview(address);
+  const { eventData, category } = useAddressPreview(address);
+
+  if (eventData === undefined) {
+    return (
+      <div className="w-5 h-5">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (eventData === null) {
+    return <p className="text-xs">{address}</p>;
+  }
+
   return (
     <>
-      {loading ? (
-        <div className="flex items-center justify-center [&_.animate-spin]:h-5 [&_.animate-spin]:w-5">
-          <Spinner />
-        </div>
-      ) : eventData ? (
-        <div
-          className={cn(
-            'rounded-xl overflow-hidden',
-            sameAsCurrentUser ? 'bg-blue-700' : 'bg-zinc-200 dark:bg-zinc-700',
-          )}
-        >
-          {category === 'usersList' && <UsersList tags={eventData.tags} />}
-          {category === 'group' && <GroupWidget groupId={eventData.tags[0][1]} />}
-        </div>
-      ) : (
-        <p>{address}</p>
-      )}
+      <div
+        className={cn(
+          'rounded-xl overflow-hidden',
+          sameAsCurrentUser ? 'bg-blue-700' : 'bg-zinc-200 dark:bg-zinc-700',
+        )}
+      >
+        {category === 'users-list' && <UsersList tags={eventData.tags} />}
+        {category === 'group' && <GroupWidget groupId={eventData.tags[0][1]} />}
+      </div>
     </>
   );
 };

--- a/src/features/chats/chat-list/components/chat-list-item/components/address-preview/types/index.ts
+++ b/src/features/chats/chat-list/components/chat-list-item/components/address-preview/types/index.ts
@@ -1,11 +1,1 @@
-export type NostrEvent = {
-  id: string;
-  kind: number;
-  pubkey: string;
-  created_at: number;
-  tags: string[][];
-  content: string;
-  sig: string;
-};
-
-export type AddressCategory = 'usersList' | 'group';
+export type AddressCategory = 'users-list' | 'group';

--- a/src/features/chats/chat-list/components/chat-list-item/components/chat-content/index.tsx
+++ b/src/features/chats/chat-list/components/chat-list-item/components/chat-content/index.tsx
@@ -1,0 +1,68 @@
+import ReactPlayer from 'react-player';
+
+import { loader } from '@/shared/utils';
+
+import { UserMention } from '@/features/users/user-mention';
+
+import { CategorizedChatContent } from '../../types';
+import { AddressPreview } from '../address-preview';
+import { NotePreview } from '../note-preview';
+
+export const ChatContent = ({
+  categorizedChatContent,
+  sameAsCurrentUser,
+  setSelectedImage,
+}: {
+  categorizedChatContent: CategorizedChatContent[];
+  setSelectedImage: React.Dispatch<React.SetStateAction<string | null>>;
+  sameAsCurrentUser: boolean;
+}) => {
+  return categorizedChatContent.map((part, i) => {
+    switch (part.category) {
+      case 'text':
+        return (
+          <p key={i} className="text-sm">
+            {part.content}
+          </p>
+        );
+      case 'image':
+        return (
+          <img
+            key={i}
+            src={loader(part.content, { w: 200 })}
+            alt="chat"
+            className="max-w-full h-40 rounded-lg mt-2 cursor-pointer"
+            onClick={() => setSelectedImage(part.content)}
+          />
+        );
+      case 'video':
+        return (
+          <div className="max-w-full rounded-lg mt-2 react-player">
+            <ReactPlayer width="100%" url={part.content} controls />
+          </div>
+        );
+      case 'url':
+        return (
+          <a
+            key={i}
+            href={part.content}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-pink-400 underline"
+          >
+            {part.content}
+          </a>
+        );
+      case 'mention':
+        return <UserMention key={i} npub={part.content} sameAsCurrentUser={sameAsCurrentUser} />;
+      case 'note':
+        return <NotePreview key={i} note={part.content} sameAsCurrentUser={sameAsCurrentUser} />;
+      case 'address':
+        return (
+          <AddressPreview key={i} address={part.content} sameAsCurrentUser={sameAsCurrentUser} />
+        );
+      default:
+        return null;
+    }
+  });
+};

--- a/src/features/chats/chat-list/components/chat-list-item/components/index.ts
+++ b/src/features/chats/chat-list/components/chat-list-item/components/index.ts
@@ -1,3 +1,4 @@
 export * from './address-preview';
+export * from './chat-content';
 export * from './chat-list-item-reactions';
 export * from './note-preview';

--- a/src/features/chats/chat-list/components/chat-list-item/index.tsx
+++ b/src/features/chats/chat-list/components/chat-list-item/index.tsx
@@ -1,7 +1,6 @@
 import { format } from 'date-fns';
 import { SmilePlusIcon, Trash2, Undo, Zap } from 'lucide-react';
 import { useState } from 'react';
-import ReactPlayer from 'react-player';
 
 import {
   ContextMenu,
@@ -11,12 +10,11 @@ import {
 } from '@/shared/components/ui/context-menu';
 
 import { UserAvatar, UserProfileModal } from '@/features/users';
-import { UserMention } from '@/features/users/user-mention';
 import { useUserProfileModal } from '@/features/users/user-profile-modal/hooks';
 
 import { cn, ellipsis, loader } from '@/shared/utils';
 
-import { AddressPreview, ChatListItemReactions, NotePreview } from './components';
+import { ChatContent, ChatListItemReactions } from './components';
 import { useChatListItem } from './hooks';
 import { ChatListItemProps } from './types';
 
@@ -55,57 +53,6 @@ export const ChatListItem = ({
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState<boolean>(false);
 
   if (!chat) return null;
-
-  const renderChatContent = () => {
-    return categorizedChatContent.map((part, i) => {
-      switch (part.category) {
-        case 'text':
-          return (
-            <p key={i} className="text-sm">
-              {part.content}
-            </p>
-          );
-        case 'image':
-          return (
-            <img
-              key={i}
-              src={loader(part.content, { w: 200 })}
-              alt="chat"
-              className="max-w-full h-40 rounded-lg mt-2 cursor-pointer"
-              onClick={() => setSelectedImage(part.content)}
-            />
-          );
-        case 'video':
-          return (
-            <div className="max-w-full rounded-lg mt-2 react-player">
-              <ReactPlayer width="100%" url={part.content} controls />
-            </div>
-          );
-        case 'url':
-          return (
-            <a
-              key={i}
-              href={part.content}
-              target="_blank"
-              rel="noreferrer"
-              className="text-xs text-pink-400 underline"
-            >
-              {part.content}
-            </a>
-          );
-        case 'mention':
-          return <UserMention key={i} npub={part.content} sameAsCurrentUser={sameAsCurrentUser} />;
-        case 'note':
-          return <NotePreview key={i} note={part.content} sameAsCurrentUser={sameAsCurrentUser} />;
-        case 'address':
-          return (
-            <AddressPreview key={i} address={part.content} sameAsCurrentUser={sameAsCurrentUser} />
-          );
-        default:
-          return null;
-      }
-    });
-  };
 
   return (
     <div className={cn('flex ml-3 gap-3 relative group', !sameAuthorAsNextChat ? 'mb-4' : 'mb-0')}>
@@ -169,7 +116,13 @@ export const ChatListItem = ({
                     categorizedReactions && 'flex-col',
                   )}
                 >
-                  <div className="[overflow-wrap:anywhere] self-start">{renderChatContent()}</div>
+                  <div className="[overflow-wrap:anywhere] self-start">
+                    <ChatContent
+                      categorizedChatContent={categorizedChatContent}
+                      sameAsCurrentUser={sameAsCurrentUser}
+                      setSelectedImage={setSelectedImage}
+                    />
+                  </div>
 
                   <div className="ml-auto flex gap-2 items-center text-end text-xs font-light cursor-default">
                     {categorizedReactions && (


### PR DESCRIPTION
This pull request includes significant changes to the chat list components, focusing on refactoring and improving the handling of address previews and chat content. The most important changes include updating the `useAddressPreview` hook, modifying the `AddressPreview` component, introducing a new `ChatContent` component, and updating related imports and usage.

Refactoring and improvements:

* [`src/features/chats/chat-list/components/chat-list-item/components/address-preview/hooks/index.ts`](diffhunk://#diff-338a3998c165ecf98cde78b13d43d1f5048688eb4d7985e8154a299fdee8e705L1-R34): Refactored the `useAddressPreview` hook to simplify the fetching logic and remove unnecessary error handling and state management.
* [`src/features/chats/chat-list/components/chat-list-item/components/address-preview/index.tsx`](diffhunk://#diff-d325d3405da6c6b9a20e6aa7a38ad37d421f8d4ed76d2e639f24155ce3d386efR3-L7): Modified the `AddressPreview` component to handle different states (loading, error, and success) more effectively. [[1]](diffhunk://#diff-d325d3405da6c6b9a20e6aa7a38ad37d421f8d4ed76d2e639f24155ce3d386efR3-L7) [[2]](diffhunk://#diff-d325d3405da6c6b9a20e6aa7a38ad37d421f8d4ed76d2e639f24155ce3d386efL17-L36)
* [`src/features/chats/chat-list/components/chat-list-item/components/address-preview/types/index.ts`](diffhunk://#diff-4e9c6db436d640a5ce4dd1aa524938fa0e45c978d5e65b33caf8313566f96feaL1-R1): Updated the `AddressCategory` type to use consistent naming conventions.

New component introduction:

* [`src/features/chats/chat-list/components/chat-list-item/components/chat-content/index.tsx`](diffhunk://#diff-4b200bc509be934e97ae87339295c472db78efb0dd17496759bf9c97b5c79207R1-R68): Introduced the `ChatContent` component to handle different types of chat content (text, image, video, URL, mention, note, address) in a modular way.

Import and usage updates:

* [`src/features/chats/chat-list/components/chat-list-item/components/index.ts`](diffhunk://#diff-bc4c2b575167d1701b6874b3972a956b1d6212dce46cf329a8196e244ea2d9a1R2): Added export for the new `ChatContent` component.
* [`src/features/chats/chat-list/components/chat-list-item/index.tsx`](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2L4): Updated imports and replaced the inline chat content rendering logic with the new `ChatContent` component. [[1]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2L4) [[2]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2L14-R17) [[3]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2L59-L109) [[4]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2L172-R125)