### PR TITLE
feat: Add copy link functionality for chats and groups

### DIFF
--- a/src/features/chats/chat-list/components/chat-list-item/hooks/index.ts
+++ b/src/features/chats/chat-list/components/chat-list-item/hooks/index.ts
@@ -13,7 +13,12 @@ import { useChatBottomBar } from '@/features/chats/chat-bottom-bar/hooks';
 
 import { useToast } from '@/shared/components/ui/use-toast';
 
-import { useActiveGroup, useActiveRelay, useZapModalState } from '@/shared/hooks';
+import {
+  useActiveGroup,
+  useActiveRelay,
+  useCopyToClipboard,
+  useZapModalState,
+} from '@/shared/hooks';
 
 import { useStore } from '@/shared/store';
 
@@ -35,6 +40,8 @@ export const useChatListItem = ({
 
   const { activeRelay } = useActiveRelay();
   const { activeGroupId } = useActiveGroup();
+
+  const { copyToClipboard } = useCopyToClipboard();
 
   const { activeUser } = useActiveUser();
 
@@ -139,6 +146,13 @@ export const useChatListItem = ({
     [activeUser, activeGroupId, activeRelay, chatsEvents, setDeletedChats, toast],
   );
 
+  const copyChatLink = (chatId: string) => {
+    copyToClipboard(
+      `${window.location.origin}/relay/${activeRelay?.replace('wss://', '')}/group/${activeGroupId}/${chatId}`,
+    );
+    toast({ description: 'Chat link copied to clipboard' });
+  };
+
   return {
     isLastChat,
     sameAuthorAsNextChat,
@@ -156,5 +170,6 @@ export const useChatListItem = ({
     activeUser,
     sendReaction,
     categorizedReactions,
+    copyChatLink,
   };
 };

--- a/src/features/chats/chat-list/components/chat-list-item/index.tsx
+++ b/src/features/chats/chat-list/components/chat-list-item/index.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { SmilePlusIcon, Trash2, Undo, Zap } from 'lucide-react';
+import { Copy, SmilePlusIcon, Trash2, Undo, Zap } from 'lucide-react';
 import { useState } from 'react';
 
 import {
@@ -45,6 +45,7 @@ export const ChatListItem = ({
     sendReaction,
     deleteChat,
     categorizedReactions,
+    copyChatLink,
   } = useChatListItem({ topChat, bottomChat, nextChat, chats, chat, setDeletedChats, chatsEvents });
 
   const { isOpen, openModal, closeModal } = useUserProfileModal();
@@ -166,6 +167,11 @@ export const ChatListItem = ({
                 >
                   <Trash2 className="h-4 w-4 mr-3" />
                   Delete
+                </ContextMenuItem>
+
+                <ContextMenuItem onClick={() => copyChatLink(chat.id)}>
+                  <Copy className="h-4 w-4 mr-3" />
+                  Copy Link
                 </ContextMenuItem>
 
                 <ContextMenuItem onClick={() => setReplyTo(chat.id)}>

--- a/src/features/chats/chat-list/hooks/index.ts
+++ b/src/features/chats/chat-list/hooks/index.ts
@@ -1,6 +1,7 @@
 import { useActiveUser } from 'nostr-hooks';
 import { useGroupChats, useGroupJoinRequests, useGroupLeaveRequests } from 'nostr-hooks/nip29';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { useActiveGroup, useActiveRelay } from '@/shared/hooks';
 
@@ -9,6 +10,8 @@ export const useChatList = () => {
   const chatRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const [deletedChats, setDeletedChats] = useState<string[]>([]);
+
+  const { chatId } = useParams();
 
   const { activeGroupId } = useActiveGroup();
   const { activeRelay } = useActiveRelay();
@@ -40,7 +43,11 @@ export const useChatList = () => {
         container.scrollTop = container.scrollHeight;
       }
     }
-  }, [processedChats]);
+
+    if (chatId) {
+      scrollToChat(chatId);
+    }
+  }, [processedChats, chatId]);
 
   const scrollToChat = (chatId: string) => {
     const chatElement = chatRefs.current[chatId];

--- a/src/features/chats/chat-top-bar/hooks/index.ts
+++ b/src/features/chats/chat-top-bar/hooks/index.ts
@@ -1,12 +1,14 @@
 import { useGroupMetadata } from 'nostr-hooks/nip29';
 
-import { useActiveGroup, useActiveRelay } from '@/shared/hooks';
+import { useActiveGroup, useActiveRelay, useCopyToClipboard } from '@/shared/hooks';
+
 import { useStore } from '@/shared/store';
 
 export const useChatTopBar = () => {
   const { activeRelay } = useActiveRelay();
   const { activeGroupId } = useActiveGroup();
   const { metadata } = useGroupMetadata(activeRelay, activeGroupId);
+  const { copyToClipboard, hasCopied } = useCopyToClipboard();
 
   const isGroupDetailsOpen = useStore((state) => state.isGroupDetailsOpen);
   const toggleGroupDetails = useStore((state) => state.toggleGroupDetails);
@@ -17,5 +19,7 @@ export const useChatTopBar = () => {
     toggleGroupDetails,
     activeRelay,
     activeGroupId,
+    copyToClipboard,
+    hasCopied,
   };
 };

--- a/src/features/chats/chat-top-bar/index.tsx
+++ b/src/features/chats/chat-top-bar/index.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Info } from 'lucide-react';
+import { ArrowLeft, CheckIcon, Info, Share2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { GroupAvatar, GroupDetails } from '@/features/groups';
@@ -14,10 +14,23 @@ import {
 } from '@/shared/components/ui/sheet';
 
 import { useChatTopBar } from './hooks';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/components/ui/tooltip.tsx';
 
 export const ChatTopBar = () => {
-  const { metadata, isGroupDetailsOpen, toggleGroupDetails, activeGroupId, activeRelay } =
-    useChatTopBar();
+  const {
+    metadata,
+    isGroupDetailsOpen,
+    toggleGroupDetails,
+    activeGroupId,
+    activeRelay,
+    copyToClipboard,
+    hasCopied,
+  } = useChatTopBar();
 
   const navigate = useNavigate();
 
@@ -29,9 +42,7 @@ export const ChatTopBar = () => {
             className="sm:hidden hover:cursor-pointer"
             onClick={() => navigate(`/relay/${activeRelay?.replace(/^wss:\/\//, '')}`)}
           />
-
           <GroupAvatar relay={activeRelay} groupId={activeGroupId} />
-
           <div className="flex flex-col">
             {/* <span className="font-light text-xs">{group?.id}</span> */}
             <span className="font-bold mt-0 mb-0">{metadata?.name}</span>
@@ -41,6 +52,30 @@ export const ChatTopBar = () => {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    copyToClipboard(
+                      `${window.location.origin}/relay/${activeRelay?.replace('wss://', '')}/group/${activeGroupId}`,
+                    )
+                  }
+                >
+                  {hasCopied ? (
+                    <CheckIcon size={25} className="text-green-600" />
+                  ) : (
+                    <Share2 size={25} />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {hasCopied ? 'Link Copied' : 'Copy Group Link To Share'}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <Sheet onOpenChange={() => toggleGroupDetails()}>
             <SheetTrigger asChild>
               <Button variant="ghost" size="icon">

--- a/src/features/groups/group-details/index.tsx
+++ b/src/features/groups/group-details/index.tsx
@@ -4,9 +4,13 @@ import { useState } from 'react';
 
 import { Button } from '@/shared/components/ui/button';
 
-import { GroupAvatar, GroupDeleteButton, GroupLeaveButton } from '@/features/groups';
+import {
+  GroupAvatar,
+  GroupDeleteButton,
+  GroupLeaveButton,
+  GroupLinkButton,
+} from '@/features/groups';
 import { UserInfoRow } from '@/features/users';
-
 import { GroupMetadataForm } from '../group-metadata-form';
 
 export const GroupDetails = ({
@@ -29,6 +33,8 @@ export const GroupDetails = ({
           {editMode ? <Undo2 className="mr-2 h-4 w-4" /> : <Edit className="mr-2 h-4 w-4" />}
           {editMode ? 'Back to view mode' : 'Edit'}
         </Button>
+
+        <GroupLinkButton />
 
         <GroupLeaveButton relay={relay} groupId={groupId} />
 

--- a/src/features/groups/group-link-button/index.tsx
+++ b/src/features/groups/group-link-button/index.tsx
@@ -1,0 +1,34 @@
+import { CheckIcon, Copy } from 'lucide-react';
+
+import { useActiveGroup, useActiveRelay } from '@/shared/hooks';
+
+import { Button } from '@/shared/components/ui/button';
+
+import { useCopyToClipboard } from '@/shared/hooks';
+
+export const GroupLinkButton = () => {
+  const { activeRelay } = useActiveRelay();
+  const { activeGroupId } = useActiveGroup();
+  const { copyToClipboard, hasCopied } = useCopyToClipboard();
+  return (
+    <Button
+      onClick={() =>
+        copyToClipboard(
+          `${window.location.origin}/relay/${activeRelay?.replace('wss://', '')}/group/${activeGroupId}`,
+        )
+      }
+      variant="outline"
+      className="flex gap-2"
+    >
+      {hasCopied ? (
+        <>
+          <CheckIcon className="text-green-600 h-4 w-4" /> Link Copied
+        </>
+      ) : (
+        <>
+          <Copy className="h-4 w-4" /> Copy Link
+        </>
+      )}
+    </Button>
+  );
+};

--- a/src/features/groups/index.ts
+++ b/src/features/groups/index.ts
@@ -3,6 +3,7 @@ export * from './group-delete-button';
 export * from './group-details';
 export * from './group-leave-button';
 export * from './group-widget';
+export * from './group-link-button';
 export * from './groups-filter-dropdown';
 export * from './groups-list';
 export * from './groups-list-item';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -65,6 +65,12 @@ export const router = createBrowserRouter([
         },
       },
       {
+        path: '/relay/:relay/group/:groupId/:chatId',
+        async lazy() {
+          return { Component: (await HomePage()).HomePage };
+        },
+      },
+      {
         path: '/relay/:relay/group/:groupId/e/:event',
         async lazy() {
           return { Component: (await HomePage()).HomePage };


### PR DESCRIPTION
This pull request introduces a new feature to copy chat and group links to the clipboard, along with several related changes across multiple files. The most important changes include adding the `useCopyToClipboard` hook, updating components to use this new feature, and making necessary adjustments to support the feature.

Enhancements to copying links:

* [`src/features/chats/chat-list/components/chat-list-item/hooks/index.ts`](diffhunk://#diff-eda9f5cce23de6d58cde6ab73c21143006b9e625f931c8184a72525948d9f0a2L16-R21): Added `useCopyToClipboard` hook and implemented `copyChatLink` function to copy chat links to the clipboard. [[1]](diffhunk://#diff-eda9f5cce23de6d58cde6ab73c21143006b9e625f931c8184a72525948d9f0a2L16-R21) [[2]](diffhunk://#diff-eda9f5cce23de6d58cde6ab73c21143006b9e625f931c8184a72525948d9f0a2R44-R45) [[3]](diffhunk://#diff-eda9f5cce23de6d58cde6ab73c21143006b9e625f931c8184a72525948d9f0a2R149-R155) [[4]](diffhunk://#diff-eda9f5cce23de6d58cde6ab73c21143006b9e625f931c8184a72525948d9f0a2R173)
* [`src/features/chats/chat-list/components/chat-list-item/index.tsx`](diffhunk://#diff-7331a45f865b5ac25c6e94c068448d468eeb34bafff1080258a2f8d8a4b80a2f2L2-R2): Integrated `copyChatLink` function into the chat list item component to enable copying chat links from the context menu. [[1]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2L2-R2) [[2]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2R48) [[3]](diffhunk://#diff-7331a45f865b5ac25c6e94068448d468eeb34bafff1080258a2f8d8a4b80a2f2R172-R176)

Updates to group link copying:

* [`src/features/chats/chat-top-bar/hooks/index.ts`](diffhunk://#diff-194ee0fb93042616a145290be44102a369ec7255e3ba784e8310255335b3cbeeL3-R11): Added `useCopyToClipboard` hook to the chat top bar hooks. [[1]](diffhunk://#diff-194ee0fb93042616a145290be44102a369ec7255e3ba784e8310255335b3cbeeL3-R11) [[2]](diffhunk://#diff-194ee0fb93042616a145290be44102a369ec7255e3ba784e8310255335b3cbeeR22-R23)
* [`src/features/chats/chat-top-bar/index.tsx`](diffhunk://#diff-50dfddfe3e38f233a5b1579d8f956c3ce74ec89cf3c23e0f350f4884fa7971eaL1-R1): Added a button to copy group links to the clipboard with a tooltip indicating the copy status. [[1]](diffhunk://#diff-50dfddfe3e38f233a5b1579d8f956c3ce74ec89cf3c23e0f350f4884fa7971eaL1-R1)R1, [[2]](diffhunk://#diff-50dfddfe3e38f233a5b1579d8f956c3ce74ec89cf3c23e0f350f4884fa7971eaR17-R33) [[3]](diffhunk://#diff-50dfddfe3e38f233a5b1579d8f956c3ce74ec89cf3c23e0f350f4884fa7971eaL32-L34) [[4]](diffhunk://#diff-50dfddfe3e38f233a5b1579d8f956c3ce74ec89cf3c23e0f350f4884fa7971eaR55-R78)
* [`src/features/groups/group-link-button/index.tsx`](diffhunk://#diff-13662caffc1159c6e36e3fed796093582a1397cc83fa57e1168176f39f72e3b0R1-R34): Created a new `GroupLinkButton` component to copy group links to the clipboard.
* [`src/features/groups/index.ts`](diffhunk://#diff-4edcd6a589232717b53e6ac1bdb51723b7c59b038fa12c252a0c53c3818a0bdcR6): Exported the new `GroupLinkButton` component.

Additional changes:

* [`src/features/groups/group-details/index.tsx`](diffhunk://#diff-78b1c6f62ed81630fa0bf09e664023e011d07f715f154ce245aff41ddf23a0ccL7-L9): Added the `GroupLinkButton` to the group details component. [[1]](diffhunk://#diff-78b1c6f62ed81630fa0bf09e664023e011d07f715f154ce245aff41ddf23a0ccL7-L9) [[2]](diffhunk://#diff-78b1c6f62ed81630fa0bf09e664023e011d07f715f154ce245aff41ddf23a0ccR37-R38)
* [`src/pages/index.tsx`](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R67-R72): Updated the router to support URLs with chat IDs for direct linking.
* [`src/features/chats/chat-list/hooks/index.ts`](diffhunk://#diff-f471678c3abb8614f96376f764825d225bacaf15a6d11003fa9d1993795ad049R4): Added `useParams` to get the chat ID from the URL and scroll to the specific chat in the chat list. [[1]](diffhunk://#diff-f471678c3abb8614f96376f764825d225bacaf15a6d11003fa9d1993795ad049R4) [[2]](diffhunk://#diff-f471678c3abb8614f96376f764825d225bacaf15a6d11003fa9d1993795ad049R14-R15) [[3]](diffhunk://#diff-f471678c3abb8614f96376f764825d225bacaf15a6d11003fa9d1993795ad049L43-R50)