### PR TITLE
Add group Search Component to the group widget list

### DIFF
--- a/src/features/groups/groups-list-widget/index.tsx
+++ b/src/features/groups/groups-list-widget/index.tsx
@@ -3,20 +3,40 @@ import { Spinner } from '@/shared/components/spinner';
 import { useActiveRelay } from '@/shared/hooks';
 import { useAllGroupsMetadataRecords } from 'nostr-hooks/nip29';
 
+import { Search } from '@/shared/components/search';
+import { useSearch } from '@/shared/components/search/hooks';
+
 export const GroupsListWidget = () => {
   const { activeRelay } = useActiveRelay();
 
   const { metadataRecords, isLoadingMetadata } = useAllGroupsMetadataRecords(activeRelay);
+
+  const groupsListData = Object.keys(metadataRecords).map((id) => ({
+    ...metadataRecords[id],
+    id,
+  }));
+
+  const { searchTerm, setSearchTerm, filteredData } = useSearch({
+    data: groupsListData,
+    searchKey: (item) => item.name,
+  });
 
   if (isLoadingMetadata) return <Spinner />;
 
   if (Object.keys(metadataRecords).length == 0) return null;
 
   return (
-    <div className="w-full grid sm:grid-cols-1 lg:grid-cols-3 xl:grid-cols-5 gap-2 p-4 overflow-x-auto">
-      {Object.keys(metadataRecords).map((groupId) => (
-        <GroupWidget key={groupId} groupId={groupId} />
-      ))}
-    </div>
+    <>
+      <div className="w-2/3 p-4 mt-0">
+        <Search searchTerm={searchTerm} setSearchTerm={setSearchTerm} placeholder="Search Groups" />
+      </div>
+      <div className="w-full grid sm:grid-cols-1 lg:grid-cols-3 xl:grid-cols-5 gap-2 p-4 overflow-x-auto mb-auto">
+        {searchTerm === ''
+          ? Object.keys(metadataRecords).map((groupId) => (
+              <GroupWidget key={groupId} groupId={groupId} />
+            ))
+          : filteredData.map((group) => <GroupWidget key={group.id} groupId={group.id} />)}
+      </div>
+    </>
   );
 };


### PR DESCRIPTION
This pull request includes significant enhancements to the `GroupsListWidget` component and the `useSearch` hook to improve search functionality and performance. The most important changes include adding a search feature to the groups list and optimizing the search hook with a debounce mechanism.

Enhancements to `GroupsListWidget`:

* [`src/features/groups/groups-list-widget/index.tsx`](diffhunk://#diff-92f630c6337484dd018841791ad6c32c9eeb7b4e715a6e7c3eece868635cbad3R6-R40): Added search functionality by incorporating `Search` and `useSearch` components, allowing users to filter groups by name.

Optimizations to `useSearch` hook:

* [`src/shared/components/search/hooks/index.ts`](diffhunk://#diff-e5ec8ee5bccda8dbfd014d3d9d879b3c0b774a52d589782cfa46878b11f2eb6fL2-R32): Replaced `useMemo` with `useCallback` for the search filter function and increased the debounce delay to 300ms for better performance.