### PR TITLE
Feat/delete thread comment

### DIFF
--- a/src/features/chats/chat-event/components/chat-event-menu/index.tsx
+++ b/src/features/chats/chat-event/components/chat-event-menu/index.tsx
@@ -1,4 +1,5 @@
-import { Copy, EllipsisIcon, MaximizeIcon } from 'lucide-react';
+import { Copy, EllipsisIcon, MaximizeIcon, Trash2 } from 'lucide-react';
+import { useActiveUser } from 'nostr-hooks';
 import { Link, useParams } from 'react-router-dom';
 
 import {
@@ -12,14 +13,21 @@ import { useActiveGroup, useActiveRelay, useCopyToClipboard } from '@/shared/hoo
 export const ChatEventMenu = ({
   event,
   isChatThread,
+  pubkey,
+  deleteThreadComment,
 }: {
   event: string;
   isChatThread?: boolean;
+  deleteThreadComment?: (commentId: string) => void;
+  pubkey?: string;
 }) => {
   const { activeRelay } = useActiveRelay();
   const { activeGroupId } = useActiveGroup();
-  const { copyToClipboard } = useCopyToClipboard();
+  const { activeUser } = useActiveUser();
+
   const { event: eventParam } = useParams();
+
+  const { copyToClipboard } = useCopyToClipboard();
 
   return (
     <DropdownMenu>
@@ -36,6 +44,15 @@ export const ChatEventMenu = ({
               <MaximizeIcon size={18} />
               Open
             </Link>
+          </DropdownMenuItem>
+        )}
+        {deleteThreadComment && activeUser?.pubkey === pubkey && (
+          <DropdownMenuItem
+            className="flex items-center gap-2 cursor-pointer text-red-500 focus:text-red-600"
+            onClick={() => deleteThreadComment(event)}
+          >
+            <Trash2 size={18} />
+            Delete
           </DropdownMenuItem>
         )}
         <DropdownMenuItem

--- a/src/features/chats/chat-event/index.tsx
+++ b/src/features/chats/chat-event/index.tsx
@@ -26,10 +26,12 @@ export const ChatEvent = memo(
     event,
     sameAsCurrentUser,
     isChatThread,
+    deleteThreadComment,
   }: {
     event: string;
     sameAsCurrentUser?: boolean;
     isChatThread?: boolean;
+    deleteThreadComment?: (commentId: string) => void;
   }) => {
     const { eventData, profile, category, isThreadsVisible, reactions, refreshReactions } =
       useChatEvent(event);
@@ -42,6 +44,10 @@ export const ChatEvent = memo(
           <Spinner />
         </div>
       );
+    }
+
+    if (eventData === null && deleteThreadComment !== undefined) {
+      return null;
     }
 
     if (eventData === null) {
@@ -82,7 +88,12 @@ export const ChatEvent = memo(
                 </span>
               </div>
               <div className="ml-auto">
-                <ChatEventMenu event={event} isChatThread={isChatThread} />
+                <ChatEventMenu
+                  event={event}
+                  isChatThread={isChatThread}
+                  deleteThreadComment={deleteThreadComment}
+                  pubkey={eventData.pubkey}
+                />
               </div>
             </div>
           )}

--- a/src/features/chats/chat-threads/components/chat-thread-comments/hooks/index.ts
+++ b/src/features/chats/chat-threads/components/chat-thread-comments/hooks/index.ts
@@ -1,15 +1,59 @@
-import { useGroupThreadComments } from 'nostr-hooks/nip29';
+import { useActiveUser } from 'nostr-hooks';
+import { deleteGroupEvent, useGroupThreadComments } from 'nostr-hooks/nip29';
+import { useState } from 'react';
 
+import { useToast } from '@/shared/components/ui/use-toast';
 import { useActiveGroup, useActiveRelay } from '@/shared/hooks';
 
 export const useChatThreadComments = (parentId: string) => {
   const { activeRelay } = useActiveRelay();
   const { activeGroupId } = useActiveGroup();
+  const { activeUser } = useActiveUser();
+
+  const { toast } = useToast();
 
   const { threadComments, isLoadingThreadComments, hasMoreThreadComments, loadMoreThreadComments } =
     useGroupThreadComments(activeRelay, activeGroupId, {
       byParentId: { parentId, waitForParentId: true },
     });
 
-  return { threadComments, isLoadingThreadComments, hasMoreThreadComments, loadMoreThreadComments };
+  const [deletedComments, setDeletedComments] = useState<string[]>([]);
+
+  const deleteThreadComment = async (commentId: string) => {
+    if (!activeUser || !activeGroupId || !activeRelay) return;
+
+    deleteGroupEvent({
+      relay: activeRelay,
+      groupId: activeGroupId,
+      eventId: commentId,
+      onSuccess: () => {
+        setDeletedComments((prev) => [...prev, commentId]);
+
+        toast({
+          title: 'Success',
+          description: 'Comment deleted successfully',
+          variant: 'default',
+        });
+      },
+      onError() {
+        toast({
+          title: 'Error',
+          description: 'Failed to delete comment',
+          variant: 'destructive',
+        });
+      },
+    });
+  };
+
+  const filteredComments = threadComments?.filter(
+    (comment) => !deletedComments.includes(comment.id),
+  );
+
+  return {
+    threadComments: filteredComments?.length ? filteredComments : undefined,
+    isLoadingThreadComments,
+    hasMoreThreadComments,
+    loadMoreThreadComments,
+    deleteThreadComment,
+  };
 };

--- a/src/features/chats/chat-threads/components/chat-thread-comments/index.tsx
+++ b/src/features/chats/chat-threads/components/chat-thread-comments/index.tsx
@@ -6,8 +6,13 @@ import { SendThreadComment } from '@/features/chats/chat-threads/components';
 import { useChatThreadComments } from './hooks';
 
 export const ChatThreadComments = ({ parentId }: { parentId: string }) => {
-  const { threadComments, isLoadingThreadComments, hasMoreThreadComments, loadMoreThreadComments } =
-    useChatThreadComments(parentId);
+  const {
+    threadComments,
+    isLoadingThreadComments,
+    hasMoreThreadComments,
+    loadMoreThreadComments,
+    deleteThreadComment,
+  } = useChatThreadComments(parentId);
 
   return (
     <div>
@@ -26,7 +31,11 @@ export const ChatThreadComments = ({ parentId }: { parentId: string }) => {
 
       <div className="flex flex-col-reverse gap-1 [&_>*]:rounded-none divide-y divide-y-reverse divide-gray-400">
         {threadComments?.map((threadComment) => (
-          <ChatEvent key={threadComment.id} event={threadComment.id} />
+          <ChatEvent
+            key={threadComment.id}
+            event={threadComment.id}
+            deleteThreadComment={deleteThreadComment}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
This pull request introduces the functionality to delete chat thread comments in the chat application. The changes include adding a delete option in the chat event menu, handling the deletion logic, and updating the state to reflect deleted comments.

Key changes include:

### Chat Event Menu Enhancements:
* Added `Trash2` icon and `useActiveUser` hook to `src/features/chats/chat-event/components/chat-event-menu/index.tsx` to support the delete option in the chat event menu.
* Updated `ChatEventMenu` component to accept `pubkey` and `deleteThreadComment` props and conditionally render the delete option if the user is authorized. [[1]](diffhunk://#diff-013be61f4effa00d12d92cadab3617d8e1c32beceee551da837d9e0b23e7d1f2R16-R31) [[2]](diffhunk://#diff-013be61f4effa00d12d92cadab3617d8e1c32beceee551da837d9e0b23e7d1f2R49-R57)

### Chat Event Component Updates:
* Modified `ChatEvent` component to accept and pass down `deleteThreadComment` prop. [[1]](diffhunk://#diff-606fd89a8001000e3c293f29ddc01a3add855fa7f55c61f77a1d6e72c4c0a3f8R29-R34) [[2]](diffhunk://#diff-606fd89a8001000e3c293f29ddc01a3add855fa7f55c61f77a1d6e72c4c0a3f8L85-R96)
* Added logic to handle null `eventData` when `deleteThreadComment` is defined, preventing rendering of deleted events.

### Chat Thread Comments Hook:
* Enhanced `useChatThreadComments` hook to include `deleteThreadComment` function, manage deleted comments state, and display toast notifications for success or failure of deletion.

### Chat Thread Comments Component:
* Updated `ChatThreadComments` component to utilize the `deleteThreadComment` function and pass it to `ChatEvent` components. [[1]](diffhunk://#diff-5812189bf1a0eaa3f75054d5ffeebf12cdfe4754e7381a0f990f7f1306d764a9L9-R15) [[2]](diffhunk://#diff-5812189bf1a0eaa3f75054d5ffeebf12cdfe4754e7381a0f990f7f1306d764a9L29-R38)