### PR TITLE
feat: add pinned groups list component and update search placeholder

### DIFF
--- a/src/features/groups/groups-list-pinned/index.tsx
+++ b/src/features/groups/groups-list-pinned/index.tsx
@@ -1,0 +1,54 @@
+import { PinIcon } from 'lucide-react';
+
+import { Link } from 'react-router-dom';
+
+import { GroupAvatar } from '@/features/groups/group-avatar';
+import { useGroupBookmark } from '@/features/groups/group-bookmark/hooks';
+import { useHomePage } from '@/pages/home/hooks';
+
+import { useActiveGroup } from '@/shared/hooks';
+import { cn } from '@/shared/utils';
+
+export const GroupsListPinned = () => {
+  const { bookmarkedGroups, activeUser } = useGroupBookmark('');
+
+  const { isCollapsed, isMobile } = useHomePage();
+
+  const { activeGroupId } = useActiveGroup();
+
+  if (!bookmarkedGroups.length || activeUser === null) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-1 pb-2 border-b">
+      <div
+        className={cn('flex items-center gap-2 p-2', isCollapsed && !isMobile && 'justify-center')}
+      >
+        {(!isCollapsed || isMobile) && <p className="text-sm font-semibold">Pinned Groups</p>}
+        <PinIcon size={17} className="rotate-45" />
+      </div>
+      {bookmarkedGroups.map((group) => (
+        <Link
+          key={group.id}
+          className={cn(
+            'flex items-center gap-2 p-2 rounded-md cursor-pointer hover:bg-accent',
+            group.id === activeGroupId && 'bg-accent',
+            isCollapsed && !isMobile && 'justify-center',
+          )}
+          to={`/?relay=${group.relay}&groupId=${group.id}`}
+        >
+          <GroupAvatar relay={group.relay} groupId={group.id} />
+          {(!isCollapsed || isMobile) && (
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-semibold truncate">{group.name}</p>
+              <p className="text-xs truncate text-muted-foreground">
+                {group.relay.replace('wss://', '')}
+              </p>
+            </div>
+          )}
+        </Link>
+      ))}
+    </div>
+  );
+};

--- a/src/features/groups/groups-list/index.tsx
+++ b/src/features/groups/groups-list/index.tsx
@@ -70,12 +70,16 @@ export const GroupsList = memo(() => {
             <Search
               searchTerm={searchTerm}
               setSearchTerm={setSearchTerm}
-              placeholder="Search Groups"
+              placeholder="Search Groups in Relay"
             />
           </DropdownMenuContent>
         </DropdownMenu>
       ) : (
-        <Search searchTerm={searchTerm} setSearchTerm={setSearchTerm} placeholder="Search Groups" />
+        <Search
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          placeholder="Search Groups in Relay"
+        />
       )}
 
       {searchTerm === ''

--- a/src/features/groups/index.ts
+++ b/src/features/groups/index.ts
@@ -8,4 +8,5 @@ export * from './group-widget';
 export * from './groups-filter-dropdown';
 export * from './groups-list';
 export * from './groups-list-item';
+export * from './groups-list-pinned';
 export * from './groups-list-widget';

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,5 +1,10 @@
 import { ChatBottomBar, ChatEvent, ChatList, ChatThreads, ChatTopBar } from '@/features/chats';
-import { GroupsFilterDropdown, GroupsList, GroupsListWidget } from '@/features/groups';
+import {
+  GroupsFilterDropdown,
+  GroupsList,
+  GroupsListPinned,
+  GroupsListWidget,
+} from '@/features/groups';
 import { RelayList, RelaySelectDropdown } from '@/features/relays/';
 import { ActiveUserInfo, UserLoginModal } from '@/features/users';
 
@@ -49,6 +54,8 @@ export function HomePage() {
                 'p-2 flex flex-col h-full gap-4 overflow-y-hidden hover:overflow-y-auto max-sm:overflow-y-auto',
               )}
             >
+              <GroupsListPinned />
+
               <GroupsList />
 
               {!activeRelay && (


### PR DESCRIPTION
This pull request introduces a new feature to display pinned groups in the groups list and makes some related adjustments to the codebase. The most important changes include adding the `GroupsListPinned` component, updating the home page to include this new component, and modifying the search placeholder text for better clarity.

### New feature: Pinned groups list
* [`src/features/groups/groups-list-pinned/index.tsx`](diffhunk://#diff-2a38c8c5dd11e033cd208172d153484b35a4d43c8f39799668bb0906c6d92ee1R1-R54): Added a new component `GroupsListPinned` to display pinned groups. This component uses various hooks and components like `useGroupBookmark`, `useHomePage`, `useActiveGroup`, and `GroupAvatar`.

### Home page updates
* [`src/pages/home/index.tsx`](diffhunk://#diff-1a85353fd4d626d682cda43134eb77c90569657758fe3e0a8be1c4c5dd7b07a4L2-R7): Updated the import statements to include `GroupsListPinned` and added the new `GroupsListPinned` component to the `HomePage` function. [[1]](diffhunk://#diff-1a85353fd4d626d682cda43134eb77c90569657758fe3e0a8be1c4c5dd7b07a4L2-R7) [[2]](diffhunk://#diff-1a85353fd4d626d682cda43134eb77c90569657758fe3e0a8be1c4c5dd7b07a4R57-R58)

### Search placeholder text update
* [`src/features/groups/groups-list/index.tsx`](diffhunk://#diff-d8ce75f9a5bbd28b682430295f57350c926a4faedcd24d282aa9dfd8c8a3c832L73-R82): Changed the placeholder text in the `Search` component from "Search Groups" to "Search Groups in Relay" for better clarity.

### Export updates
* [`src/features/groups/index.ts`](diffhunk://#diff-4edcd6a589232717b53e6ac1bdb51723b7c59b038fa12c252a0c53c3818a0bdcR11): Added export for the new `GroupsListPinned` component.