### PR TITLE
fix implement PinnedListItem component for displaying pinned/unpinned button

### DIFF
--- a/src/features/groups/groups-list-pinned/components/index.ts
+++ b/src/features/groups/groups-list-pinned/components/index.ts
@@ -1,0 +1,1 @@
+export * from './pinned-list-item';

--- a/src/features/groups/groups-list-pinned/components/pinned-list-item/index.tsx
+++ b/src/features/groups/groups-list-pinned/components/pinned-list-item/index.tsx
@@ -1,0 +1,70 @@
+import { PinOffIcon } from 'lucide-react';
+
+import { useGroupMetadata } from 'nostr-hooks/nip29';
+import { Link } from 'react-router-dom';
+
+import { GroupAvatar } from '@/features/groups/group-avatar';
+import { useGroupBookmark } from '@/features/groups/group-bookmark/hooks';
+
+import { useHomePage } from '@/pages/home/hooks';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/components/ui/tooltip';
+import { useActiveGroup } from '@/shared/hooks';
+import { cn, ellipsis } from '@/shared/utils';
+
+export const PinnedListItem = ({ relay, groupId }: { relay: string; groupId: string }) => {
+  const { metadata } = useGroupMetadata(relay, groupId);
+  const { removeGroupFromBookmarks } = useGroupBookmark(groupId, metadata?.name);
+  const { activeGroupId } = useActiveGroup();
+  const { isCollapsed, isMobile } = useHomePage();
+
+  return (
+    <Link
+      className={cn(
+        'flex items-center gap-2 p-2 rounded-md cursor-pointer hover:bg-accent',
+        groupId === activeGroupId && 'bg-accent',
+        isCollapsed && !isMobile && 'justify-center',
+      )}
+      to={`/?relay=${relay}&groupId=${groupId}`}
+    >
+      <GroupAvatar relay={relay} groupId={groupId} />
+      {(!isCollapsed || isMobile) && (
+        <>
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-semibold truncate">
+              {metadata?.name || ellipsis(groupId, 7)}
+            </p>
+            <p className="text-xs truncate text-muted-foreground">{relay.replace('wss://', '')}</p>
+          </div>
+          <div
+            className="ms-auto rounded hover:bg-black/20"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PinOffIcon
+                    size={25}
+                    className="p-1"
+                    onClick={() => removeGroupFromBookmarks()}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Unpin</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </>
+      )}
+    </Link>
+  );
+};

--- a/src/features/groups/groups-list-pinned/index.tsx
+++ b/src/features/groups/groups-list-pinned/index.tsx
@@ -1,21 +1,17 @@
 import { PinIcon } from 'lucide-react';
 
-import { Link } from 'react-router-dom';
-
-import { GroupAvatar } from '@/features/groups/group-avatar';
-import { GroupBookmark } from '@/features/groups/group-bookmark';
 import { useGroupBookmark } from '@/features/groups/group-bookmark/hooks';
+
 import { useHomePage } from '@/pages/home/hooks';
 
-import { useActiveGroup } from '@/shared/hooks';
 import { cn } from '@/shared/utils';
+
+import { PinnedListItem } from './components';
 
 export const GroupsListPinned = () => {
   const { bookmarkedGroups, activeUser } = useGroupBookmark('');
 
   const { isCollapsed, isMobile } = useHomePage();
-
-  const { activeGroupId } = useActiveGroup();
 
   if (!bookmarkedGroups.length || activeUser === null) {
     return null;
@@ -30,36 +26,7 @@ export const GroupsListPinned = () => {
         <PinIcon size={17} className="rotate-45" />
       </div>
       {bookmarkedGroups.map((group) => (
-        <Link
-          key={group.id}
-          className={cn(
-            'flex items-center gap-2 p-2 rounded-md cursor-pointer hover:bg-accent',
-            group.id === activeGroupId && 'bg-accent',
-            isCollapsed && !isMobile && 'justify-center',
-          )}
-          to={`/?relay=${group.relay}&groupId=${group.id}`}
-        >
-          <GroupAvatar relay={group.relay} groupId={group.id} />
-          {(!isCollapsed || isMobile) && (
-            <>
-              <div className="flex flex-col gap-1">
-                <p className="text-sm font-semibold truncate">{group.name}</p>
-                <p className="text-xs truncate text-muted-foreground">
-                  {group.relay.replace('wss://', '')}
-                </p>
-              </div>
-              <div
-                className="ms-auto rounded hover:bg-black/20 [&_*]:w-8 [&_*]:h-8 [&_*]:p-1.5"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                }}
-              >
-                <GroupBookmark groupId={group.id} groupName={group.name} />
-              </div>
-            </>
-          )}
-        </Link>
+        <PinnedListItem key={group.id} relay={group.relay} groupId={group.id} />
       ))}
     </div>
   );


### PR DESCRIPTION
…ed groups
This pull request introduces a new component `PinnedListItem` and refactors the `GroupsListPinned` component to use it. The changes aim to modularize the code and improve readability. The most important changes include exporting the new component, implementing the `PinnedListItem` component, and updating the `GroupsListPinned` component to use the new component.

### New Component Implementation:

* [`src/features/groups/groups-list-pinned/components/index.ts`](diffhunk://#diff-bd209c0864a925cf13ffa498b28e891b3513b3702e028ec2ecf686b3f4ca1dafR1): Exported the new `PinnedListItem` component.
* [`src/features/groups/groups-list-pinned/components/pinned-list-item/index.tsx`](diffhunk://#diff-258005dd2fb9336bb6f87efcc77c0b98b83924acb2f3d5cc0dbc9a150ff484cdR1-R70): Implemented the `PinnedListItem` component, which includes the group avatar, metadata, and an unpin button with a tooltip.

### Refactoring:

* [`src/features/groups/groups-list-pinned/index.tsx`](diffhunk://#diff-2a38c8c5dd11e033cd208172d153484b35a4d43c8f39799668bb0906c6d92ee1L3-L19): Removed unused imports and added the import for the new `PinnedListItem` component.
* [`src/features/groups/groups-list-pinned/index.tsx`](diffhunk://#diff-2a38c8c5dd11e033cd208172d153484b35a4d43c8f39799668bb0906c6d92ee1L33-R29): Updated the `GroupsListPinned` component to use the `PinnedListItem` component for rendering each bookmarked group.