### PR TITLE
Add Video component and update chat event hooks for video support

### DIFF
--- a/src/features/chats/chat-event/components/follow-set/components/follow-set-item/index.tsx
+++ b/src/features/chats/chat-event/components/follow-set/components/follow-set-item/index.tsx
@@ -14,7 +14,7 @@ export const FollowSetItem = ({ pubkey }: { pubkey: string }) => {
         className="flex items-center gap-2 p-2 rounded-md bg-black bg-opacity-20 hover:bg-opacity-25 hover:cursor-pointer"
         onClick={openModal}
       >
-        <span className="[&_*]:w-8 [&_*]:h-8">
+        <span className="[&_span]:w-8 [&_span]:h-8">
           <UserAvatar pubkey={pubkey} />
         </span>
         <span className="text-sm">

--- a/src/features/chats/chat-event/components/index.ts
+++ b/src/features/chats/chat-event/components/index.ts
@@ -7,3 +7,4 @@ export * from './live-stream';
 export * from './long-form-content';
 export * from './note';
 export * from './picture';
+export * from './video';

--- a/src/features/chats/chat-event/components/video/index.tsx
+++ b/src/features/chats/chat-event/components/video/index.tsx
@@ -1,0 +1,67 @@
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { useMemo } from 'react';
+import ReactPlayer from 'react-player';
+
+import { ChatContent } from '@/features/chats/chat-list/components/chat-list-item/components';
+import { categorizeChatContent } from '@/features/chats/chat-list/components/chat-list-item/utils';
+
+import { loader } from '@/shared/utils';
+
+export const Video = ({ event }: { event: NDKEvent }) => {
+  const categorizedChatContent = useMemo(
+    () => categorizeChatContent(event.content || ''),
+    [event.content],
+  );
+
+  const titleTag = event.tags.find(([t]) => t === 'title');
+  const title = titleTag ? titleTag[1] : '';
+
+  const videoSources = event.tags
+    .filter(([t]) => t === 'imeta')
+    .map((imetaTag) => {
+      const urlTag = imetaTag.find((val) => val.startsWith('url '));
+      const fallbackTags = imetaTag.filter((val) => val.startsWith('fallback '));
+      const thumbnailTag = imetaTag.find((val) => val.startsWith('image '));
+      const durationTag = event.tags.find(([t]) => t === 'duration');
+
+      return {
+        url: urlTag ? urlTag.split(' ')[1] : null,
+        fallbacks: fallbackTags.map((val) => val.split(' ')[1]),
+        thumbnail: thumbnailTag ? thumbnailTag.split(' ')[1] : null,
+        duration: durationTag ? durationTag[1] : 'Unknown',
+      };
+    });
+
+  const hashtags = event.tags.filter(([t]) => t === 't').map(([_, tag]) => `#${tag}`);
+
+  return (
+    <div className="w-full set-max-h overflow-auto flex flex-col gap-2 p-2">
+      <h5 className="text-lg font-semibold">{title}</h5>
+      <div className="[&_*]:text-base">
+        <ChatContent categorizedChatContent={categorizedChatContent} />
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {videoSources.length > 0 &&
+          videoSources.map((video, index) =>
+            video.url ? (
+              <div key={index} className="max-w-full rounded-lg mt-2 react-player">
+                <ReactPlayer
+                  width="100%"
+                  url={video.url}
+                  controls
+                  light={video.thumbnail ? loader(video.thumbnail) : false}
+                />
+              </div>
+            ) : null,
+          )}
+      </div>
+
+      {hashtags.length > 0 && (
+        <p className="text-sm text-secondary-foreground mt-2">
+          <strong>Tags:</strong> {hashtags.join(', ')}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/features/chats/chat-event/hook/index.ts
+++ b/src/features/chats/chat-event/hook/index.ts
@@ -3,7 +3,7 @@ import { useNdk, useProfile } from 'nostr-hooks';
 import { useEffect, useState } from 'react';
 
 import { useHomePage } from '@/pages/home/hooks';
-import { useLazyLoad } from '@/shared/hooks/use-lazy-load';
+import { useLazyLoad } from '@/shared/hooks';
 
 import { fetchReactions } from '../utils';
 
@@ -14,6 +14,7 @@ type EventCategory =
   | 'long-form-content'
   | 'poll'
   | 'picture'
+  | 'video'
   | 'live-stream'
   | 'highlight';
 
@@ -39,6 +40,8 @@ export const useChatEvent = (event: string) => {
           setCategory('note');
         } else if (event.kind === 20) {
           setCategory('picture');
+        } else if (event.kind === 21) {
+          setCategory('video');
         } else if (event.kind === 1068) {
           setCategory('poll');
         } else if (event.kind === 9802) {

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -2,6 +2,7 @@ export { useActiveGroup } from './use-active-group';
 export { useActiveRelay } from './use-active-relay';
 export { useBlossomUpload } from './use-blossom-upload';
 export { useCopyToClipboard } from './use-copy-to-clipboard';
+export { useLazyLoad } from './use-lazy-load';
 export { useLoginModalState } from './use-login-modal-state';
 export { useSendContent } from './use-send-content';
 export { useUploadMedia } from './use-upload-media';

--- a/src/shared/utils/getNostrLink/index.ts
+++ b/src/shared/utils/getNostrLink/index.ts
@@ -1,0 +1,20 @@
+import { nip19 } from 'nostr-tools';
+
+export const getNostrLink = (
+  eventId: string,
+  pubkey: string | undefined,
+  kind: number | undefined,
+) => {
+  try {
+    const neventLink = nip19.neventEncode({
+      id: eventId,
+      author: pubkey,
+      kind,
+    });
+
+    return neventLink;
+  } catch (error) {
+    console.error('Error encoding Nostr link:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
This pull request introduces a new feature for handling video content in the chat events and includes some refactoring to improve code organization. The most important changes are listed below:

### New Feature: Video Content

* Added a new `Video` component to handle video content within chat events, including parsing video metadata and rendering video players.
* Updated the `useChatEvent` hook to categorize events with kind `21` as video events.
* Added `video` to the `EventCategory` type definition.
* Exported the new `video` component from the index file.

### Refactoring

* Updated the `useLazyLoad` import path to be more consistent with other shared hooks.
* Exported the `useLazyLoad` hook from the shared hooks index file.

### Minor Changes

* Corrected the CSS selector for the `UserAvatar` component in the `FollowSetItem` component.

### Utility Function

* Added a new utility function `getNostrLink` to generate Nostr links using the `nip19` library.