### PR TITLE
Feat/improve richtext

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,14 +65,17 @@
     "react-dropzone": "^14.2.10",
     "react-hook-form": "^7.50.1",
     "react-infinite-scroll-component": "^6.1.0",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^10.1.0",
     "react-player": "^2.16.0",
     "react-resizable-panels": "^1.0.10",
     "react-router-dom": "^6.21.3",
     "react-textarea-autosize": "^8.5.4",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^1.4.0",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
+    "unist-util-visit": "^5.0.0",
     "vaul": "^0.8.9",
     "zod": "^3.23.4",
     "zustand": "^4.5.2"
@@ -92,6 +95,6 @@
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.4.5",
-    "vite": "^5.2.10"
+    "vite": "^6.2.2"
   }
 }

--- a/src/features/chats/chat-event/components/long-form-content/index.tsx
+++ b/src/features/chats/chat-event/components/long-form-content/index.tsx
@@ -1,9 +1,9 @@
-import ReactMarkdown from 'react-markdown';
+import { Markdown } from '@/shared/components/markdown';
 
 export const LongFormContent = ({ content }: { content: string }) => {
   return (
     <div className="set-max-h flex flex-col gap-1 p-2 rounded-md overflow-y-auto [overflow-wrap:anywhere]">
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <Markdown content={content} />
     </div>
   );
 };

--- a/src/features/chats/chat-list/components/chat-list-item/components/chat-content/index.tsx
+++ b/src/features/chats/chat-list/components/chat-list-item/components/chat-content/index.tsx
@@ -4,6 +4,7 @@ import ReactPlayer from 'react-player';
 import { ChatEvent } from '@/features/chats';
 import { UserMention } from '@/features/users/user-mention';
 
+import { Markdown } from '@/shared/components/markdown';
 import { loader } from '@/shared/utils';
 
 import { CategorizedChatContent } from '../../types';
@@ -18,11 +19,7 @@ export const ChatContent = ({
   return categorizedChatContent.map((part, i) => {
     switch (part.category) {
       case 'text':
-        return (
-          <p key={i} className="text-sm">
-            {part.content}
-          </p>
-        );
+        return <Markdown key={i} content={part.content} className="text-sm" />;
       case 'image':
         return (
           <div key={i}>

--- a/src/features/chats/chat-list/components/chat-list-item/index.tsx
+++ b/src/features/chats/chat-list/components/chat-list-item/index.tsx
@@ -85,7 +85,7 @@ export const ChatListItem = memo(
               <ContextMenuTrigger>
                 <div
                   className={cn(
-                    'p-2 mt-1 rounded-lg max-w-xl max-sm:max-w-72 whitespace-pre-wrap',
+                    'p-2 mt-1 rounded-lg max-w-[75vw] sm:max-w-[45vw] whitespace-pre-wrap',
                     sameAsCurrentUser
                       ? 'mr-2 bg-blue text-blue-foreground'
                       : 'bg-secondary text-secondary-foreground',

--- a/src/shared/components/markdown/components/code/index.tsx
+++ b/src/shared/components/markdown/components/code/index.tsx
@@ -1,0 +1,72 @@
+import { CheckIcon, Copy } from 'lucide-react';
+
+import { Button } from '@/shared/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/components/ui/tooltip';
+import { useCopyToClipboard } from '@/shared/hooks';
+
+interface CustomCodeProps extends React.HTMLAttributes<HTMLElement> {
+  inline?: boolean;
+  children?: React.ReactNode;
+}
+
+export const Code: React.FC<CustomCodeProps> = ({ inline, children, className, ...props }) => {
+  const { copyToClipboard, hasCopied } = useCopyToClipboard();
+
+  let language = '';
+  if (className) {
+    const match = /language-(\w+)/.exec(className);
+    if (match) {
+      language = match[1];
+    }
+  }
+
+  if (inline) {
+    return (
+      <code className="bg-primary/20 font-mono font-thin px-1 rounded-md" {...props}>
+        {children}
+      </code>
+    );
+  }
+
+  return (
+    <div className="flex flex-col w-full bg-primary/20 rounded-lg">
+      <div className="flex items-center">
+        {language && (
+          <div className="bg-primary/20 text-xs font-medium rounded-md px-2 py-0.5 m-1">
+            {language.toUpperCase()}
+          </div>
+        )}
+
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                className="m-1 ms-auto bg-unset hover:bg-primary/15 text-current hover:text-current h-6 p-1"
+                onClick={() => copyToClipboard(children?.toString() || '')}
+              >
+                {hasCopied ? (
+                  <CheckIcon size={16} className="text-green-600" />
+                ) : (
+                  <Copy size={16} />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{hasCopied ? 'Code Copied!' : 'Copy Code To Clipboard'}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+
+      <pre className="max-w-[70vw] sm:max-w-[40vw] overflow-x-auto font-mono text-xs p-2">
+        <code className="bg-transparent leading-relaxed font-thin" {...props}>
+          {children}
+        </code>
+      </pre>
+    </div>
+  );
+};

--- a/src/shared/components/markdown/index.tsx
+++ b/src/shared/components/markdown/index.tsx
@@ -1,0 +1,41 @@
+import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
+
+import { cn } from '@/shared/utils';
+
+import { Code } from './components/code';
+import { rehypeInlineCodeProperty } from './utils';
+
+export const Markdown = ({ content, className }: { content: string; className?: string }) => {
+  return (
+    <div className={cn('prose prose-invert max-w-full relative z-0', className)}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        rehypePlugins={[rehypeInlineCodeProperty]}
+        components={{
+          a: ({ node, ...props }) => (
+            <a
+              {...props}
+              className="text-blue-400 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          ),
+          strong: ({ children }) => <strong className="font-bold">{children}</strong>,
+          em: ({ children }) => <em className="italic">{children}</em>,
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-4 border-primary pl-4 italic opacity-80">
+              {children}
+            </blockquote>
+          ),
+          code: Code,
+          img: ({ node, ...props }) => <img {...props} className="rounded-md max-w-full" />,
+          hr: () => <hr className="border-t border-primary/50 my-6" />,
+        }}
+      >
+        {content?.replace(/\*([^\*]+)\*/g, '**$1**')}
+      </ReactMarkdown>
+    </div>
+  );
+};

--- a/src/shared/components/markdown/utils/index.ts
+++ b/src/shared/components/markdown/utils/index.ts
@@ -1,0 +1,16 @@
+import { visit } from 'unist-util-visit';
+
+export function rehypeInlineCodeProperty() {
+  return (tree: any) => {
+    visit(tree, 'element', (node: any, index: number | undefined, parent: any) => {
+      if (node.tagName === 'code') {
+        node.properties = node.properties || {};
+        if (parent && parent.tagName === 'pre') {
+          node.properties.inline = false;
+        } else {
+          node.properties.inline = true;
+        }
+      }
+    });
+  };
+}


### PR DESCRIPTION
This pull request includes several updates to dependencies, refactoring of markdown rendering, and enhancements to the user interface for code blocks. The most important changes include updating dependencies, refactoring markdown components, and modifying the chat content components to use the new markdown component.

### Dependency Updates:
* Updated `react-markdown` from `^9.0.1` to `^10.1.0` and added new dependencies `remark-breaks`, `remark-gfm`, and `unist-util-visit` in `package.json`.
* Updated `vite` from `^5.2.10` to `^6.2.2` in `package.json`.

### Markdown Component Refactoring:
* Replaced `ReactMarkdown` with a new `Markdown` component in `src/features/chats/chat-event/components/long-form-content/index.tsx`.
* Added a new `Markdown` component with enhanced rendering capabilities in `src/shared/components/markdown/index.tsx`.
* Implemented a custom `Code` component for better code block rendering and added copy-to-clipboard functionality in `src/shared/components/markdown/components/code/index.tsx`.
* Added a utility function `rehypeInlineCodeProperty` to handle inline code properties in `src/shared/components/markdown/utils/index.ts`.

### Chat Content Component Modifications:
* Modified `ChatContent` component to use the new `Markdown` component for text content in `src/features/chats/chat-list/components/chat-list-item/components/chat-content/index.tsx`. [[1]](diffhunk://#diff-4b200bc509be934e97ae87339295c472db78efb0dd17496759bf9c97b5c79207R7) [[2]](diffhunk://#diff-4b200bc509be934e97ae87339295c472db78efb0dd17496759bf9c97b5c79207L21-R22)
* Updated styling for chat list items to improve layout responsiveness in `src/features/chats/chat-list/components/chat-list-item/index.tsx`.