### PR TITLE
Feat/add voice message event

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^0.2.1",
-    "date-fns": "^4.0.0",
+    "date-fns": "^3.3.1",
     "dexie": "^4.0.11",
     "embla-carousel-react": "^8.0.0-rc19",
     "framer-motion": "^11.3.21",

--- a/src/features/chats/chat-event/components/index.ts
+++ b/src/features/chats/chat-event/components/index.ts
@@ -22,5 +22,6 @@ export * from './picture';
 export * from './publication-content';
 export * from './publication-index';
 export * from './video';
+export * from './voice-message';
 export * from './wiki';
 export * from './zap-goal';

--- a/src/features/chats/chat-event/components/voice-message/index.tsx
+++ b/src/features/chats/chat-event/components/voice-message/index.tsx
@@ -1,0 +1,52 @@
+import { NostrEvent } from '@nostr-dev-kit/ndk';
+
+export const VoiceMessage = ({ event }: { event: NostrEvent }) => {
+  const titleTag = event.tags.find(([t]) => t === 'title');
+  const title = titleTag ? titleTag[1] : '';
+
+  const imetaTags = event.tags.filter(([t]) => t === 'imeta');
+  const audioSources = imetaTags.map((imetaTag) => {
+    const urlTag = imetaTag.find((val) => val.startsWith('url '));
+    const durationTag = imetaTag.find((val) => val.startsWith('duration '));
+    const waveformTag = imetaTag.find((val) => val.startsWith('waveform '));
+    return {
+      url: urlTag ? urlTag.split(' ')[1] : event.content,
+      duration: durationTag ? durationTag.split(' ')[1] : undefined,
+      waveform: waveformTag
+        ? waveformTag
+            .split(' ')
+            .slice(1)
+            .map((v) => parseFloat(v))
+        : [],
+    };
+  });
+
+  const hashtags = event.tags.filter(([t]) => t === 't').map(([, tag]) => `#${tag}`);
+
+  return (
+    <div className="w-full set-max-h overflow-auto flex flex-col gap-2 p-2">
+      {title && <h5 className="text-lg font-semibold">{title}</h5>}
+
+      <div className="mt-4 space-y-4">
+        {audioSources.map((audio, index) =>
+          audio.url ? (
+            <div key={index} className="w-full rounded-lg mt-2">
+              <audio controls src={audio.url} className="w-full" preload="metadata" />
+              {audio.duration && (
+                <p className="text-sm text-secondary-foreground mt-1">
+                  <strong>Duration:</strong> {audio.duration}s
+                </p>
+              )}
+            </div>
+          ) : null,
+        )}
+      </div>
+
+      {hashtags.length > 0 && (
+        <p className="text-sm text-secondary-foreground mt-2">
+          <strong>Tags:</strong> {hashtags.join(', ')}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/features/chats/chat-event/index.tsx
+++ b/src/features/chats/chat-event/index.tsx
@@ -34,6 +34,7 @@ import {
   PublicationContent,
   PublicationIndex,
   Video,
+  VoiceMessage,
   Wiki,
   ZapGoal,
 } from './components';
@@ -154,6 +155,7 @@ export const ChatEvent = memo(
         {category === 'live-stream' && <LiveStream event={eventData} />}
         {category === 'picture' && <Picture event={eventData} />}
         {category === 'video' && <Video event={eventData} />}
+        {category === 'voice-message' && <VoiceMessage event={eventData} />}
         {category === 'community' && <Community event={eventData} />}
         {category === 'git-repo' && <GitRepo event={eventData} />}
         {category === 'app-recommendation' && <AppRecommendation event={eventData} />}

--- a/src/features/chats/chat-event/types/index.ts
+++ b/src/features/chats/chat-event/types/index.ts
@@ -11,6 +11,7 @@ export type EventCategory =
   | 'code-snippet'
   | 'picture'
   | 'video'
+  | 'voice-message'
   | 'live-stream'
   | 'highlight'
   | 'git-repo'

--- a/src/features/chats/chat-event/utils/index.ts
+++ b/src/features/chats/chat-event/utils/index.ts
@@ -10,6 +10,7 @@ export const EVENT_CATEGORY_MAP: Record<number, EventCategory> = {
   20: 'picture',
   21: 'video',
   1068: 'poll',
+  1222: 'voice-message',
   1337: 'code-snippet',
   9041: 'zap-goal',
   9802: 'highlight',

--- a/src/shared/hooks/use-blossom-upload/index.ts
+++ b/src/shared/hooks/use-blossom-upload/index.ts
@@ -4,7 +4,7 @@ import { RefObject, useState } from 'react';
 
 import { useToast } from '@/shared/components/ui/use-toast';
 
-const DEFAULT_SERVER = 'https://blossom.primal.net/';
+const DEFAULT_SERVER = 'https://blossom.primal.net';
 
 export const useBlossomUpload = <T extends HTMLTextAreaElement | HTMLInputElement>(
   setMediaUrl: (url: string | ((prev: string) => string)) => void,

--- a/src/shared/hooks/use-smart-navigation/index.ts
+++ b/src/shared/hooks/use-smart-navigation/index.ts
@@ -1,18 +1,12 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export const useSmartNavigation = () => {
   const navigate = useNavigate();
-  const location = useLocation();
 
   const navigateBack = () => {
-    const hasNavigationState = location.state?.from;
+    const canGoBack = window.history.state?.idx > 0;
 
-    const hasInternalReferrer =
-      document.referrer && document.referrer.includes(window.location.origin);
-
-    const hasHistoryEntries = window.history.length > 1;
-
-    if (hasNavigationState || (hasInternalReferrer && hasHistoryEntries)) {
+    if (canGoBack) {
       navigate(-1);
     } else {
       navigate('/');


### PR DESCRIPTION
This pull request introduces support for "voice message" events in the chat feature, allowing users to see and play voice messages within chat events. The implementation includes a new component for rendering voice messages, updates to event categorization, and minor improvements to shared hooks.

**Voice message feature integration:**

* Added a new `VoiceMessage` component (`src/features/chats/chat-event/components/voice-message/index.tsx`) to display voice message events, extracting relevant metadata (title, audio sources, duration, waveform, hashtags) from event tags.
* Updated the event category type (`EventCategory`) and mapping to include the new `voice-message` category and corresponding event code (1222). [[1]](diffhunk://#diff-4516dd158f5ced678404b9fde43dee146606af6611c842a169d169de480658aeR14) [[2]](diffhunk://#diff-65094e96acd6b44a541d54b224cfb17fbfb89940aae37a92b7732a3ed9bfd06cR13)
* Integrated the `VoiceMessage` component into the chat event rendering logic, so events with the `voice-message` category are displayed appropriately. [[1]](diffhunk://#diff-606fd89a8001000e3c293f29ddc01a3add855fa7f55c61f77a1d6e72c4c0a3f8R37) [[2]](diffhunk://#diff-606fd89a8001000e3c293f29ddc01a3add855fa7f55c61f77a1d6e72c4c0a3f8R158)
* Exported the new `VoiceMessage` component for use in other modules.

**Minor improvements:**

* Fixed the default server URL in the `useBlossomUpload` hook by removing the trailing slash for consistency.
* Simplified navigation logic in the `useSmartNavigation` hook by removing unused imports and improving the back navigation condition to rely on browser history index.